### PR TITLE
Fix message typo in emphasis.R

### DIFF
--- a/R/emphasis.R
+++ b/R/emphasis.R
@@ -81,7 +81,7 @@ emphasis <- function(brts,
   
   
   cat("\n", msg5, sep = "\n")
-  cat("Phase 2: Assesing required MC sampling size \n")
+  cat("Phase 2: Assessing required MC sampling size \n")
   
   for (s in pilot_sample_size) {
     cat(paste("\n Sampling size: ", as.character(s), "\n"))


### PR DESCRIPTION
## Summary
- fix a typo in `Phase 2` message output

## Testing
- `R CMD build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed82a06d483238bec8d3eaf7bcb44